### PR TITLE
Rails 3 compatibility

### DIFF
--- a/lib/scrobbler2.rb
+++ b/lib/scrobbler2.rb
@@ -1,5 +1,5 @@
 require 'rubygems'
-require 'activesupport'
+require 'active_support/all'
 require 'httparty'
 $: << File.dirname(__FILE__)
 


### PR DESCRIPTION
Hi there. This is a fix for the deprecated `require 'activesupport'`, replacing it with 
`active_support` to make it compatible with Rails 3, and adding `/all` which is necessary to include `cattr_accessor`).
